### PR TITLE
Fix namespace in controller generated

### DIFF
--- a/Lube/GeneratorBundle/Command/GenerateAPICommand.php
+++ b/Lube/GeneratorBundle/Command/GenerateAPICommand.php
@@ -208,7 +208,7 @@ EOT
 
         $this->renderFile('controller.php.twig', 
                            $BundlePath . '/Controller/' . $EntityName . 'Controller.php',
-                           array('Namespace' => $Namespace,
+                           array('Namespace' => $input->getOption('bundle'),
                                  'Bundle'    => $Bundle, 
                                  'Entity'    => $Entity)
                          );


### PR DESCRIPTION
The namespace of the generated controller, should be the entered value in "Target bundle For API Controller"
